### PR TITLE
automatically token refresh + detect podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ export const REFRESH_TOKEN = "your-very-long-spotify-refresh-token-here";
 ## further information
 
 - [Gather Websocket API docs](https://gathertown.notion.site/Gather-Websocket-API-bf2d5d4526db412590c3579c36141063)
+- [Ben Wiz: How to create a Spotify refresh token the easy way](https://benwiz.com/blog/create-spotify-refresh-token/)
 - [Spotify dev guide: Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization/code-flow/)
 - [Matthew Stead's Spotify OAuth Refresher](https://github.com/matievisthekat/spotify-oauth-refresher)

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ export const API_KEY = "your-api-key-here";
 export const SPACE_ID = "gatherSpaceId\\gatherSpaceName";
 export const CLIENT_ID = "your-spotify-client-id";
 export const CLIENT_SECRET = "your-spotify-client-secret";
-export const ACCESS_TOKEN =
-  "your-very-long-spotify-token-here";
-export const REFRESH_TOKEN =
-  "your-very-long-spotify-refresh-token-here";
+export const ACCESS_TOKEN = "your-very-long-spotify-token-here";
+export const REFRESH_TOKEN = "your-very-long-spotify-refresh-token-here";
 ```
 
 ## running

--- a/README.md
+++ b/README.md
@@ -10,18 +10,25 @@ prereq: have NodeJS and npm installed
 
 run `npm install`
 
-put your Gather and Spotify API keys in a file named `api-key.js` like so:
+put your [Gather API key](https://gather.town/apiKeys), -spaceId, [Spotify API credentials](https://developer.spotify.com/dashboard/applications) and [-tokens](https://developer.spotify.com/console/get-users-currently-playing-track/) in a file named `api-key.js` like so:
 
 ```js
 export const API_KEY = "your-api-key-here";
-export const SPOTIFY_KEY = "your-very-long-spotify-token-here";
+export const SPACE_ID = "gatherSpaceId\\gatherSpaceName";
+export const CLIENT_ID = "your-spotify-client-id";
+export const CLIENT_SECRET = "your-spotify-client-secret";
+export const ACCESS_TOKEN =
+  "your-very-long-spotify-token-here";
+export const REFRESH_TOKEN =
+  "your-very-long-spotify-refresh-token-here";
 ```
-
-get the gather one here: https://gather.town/apiKeys
-and spotify here: https://developer.spotify.com/console/get-users-currently-playing-track/
-
-replace the `SPACE_ID` in index.ts with your own spaceId
 
 ## running
 
 `npm run start`
+
+## further information
+
+- [Gather Websocket API docs](https://gathertown.notion.site/Gather-Websocket-API-bf2d5d4526db412590c3579c36141063)
+- [Spotify dev guide: Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization/code-flow/)
+- [Matthew Stead's Spotify OAuth Refresher](https://github.com/matievisthekat/spotify-oauth-refresher)

--- a/index.ts
+++ b/index.ts
@@ -1,45 +1,61 @@
 import axios from "axios";
-import { API_KEY, SPOTIFY_KEY } from "./api-key";
+import { API_KEY, SPACE_ID, CLIENT_ID, CLIENT_SECRET, ACCESS_TOKEN, REFRESH_TOKEN } from "./api-key";
 import { Game } from "@gathertown/gather-game-client";
 global.WebSocket = require("isomorphic-ws");
+const Updater = require("spotify-oauth-refresher");
 
-const SPACE_ID = "oxrhEtb3sV7VutbQ\\GatherOffice";
+// token refresher setup
+const api = new Updater({ clientId: CLIENT_ID, clientSecret: CLIENT_SECRET });
+api.setAccessToken(ACCESS_TOKEN);
+api.setRefreshToken(REFRESH_TOKEN);
 
-// setup
-
+// gather game client setup
 const game = new Game(() => Promise.resolve({ apiKey: API_KEY }));
 game.connect(SPACE_ID); // replace with your spaceId of choice
 game.subscribeToConnection((connected) => console.log("connected?", connected));
 
-//
-
 // check every 5s
-
 setInterval(async () => {
-	const res = await axios
-		.get("https://api.spotify.com/v1/me/player/currently-playing", {
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${SPOTIFY_KEY}`,
-			},
-		})
-		.catch((e) => {
-			console.error(e);
-			process.exit(0);
-		});
+  const res = await api.request({
+    url: "https://api.spotify.com/v1/me/player/currently-playing",
+    method: "get",
+    authType: "bearer",
+  });
 
-	console.log(res.data.item.name);
+  let playing = "";
+  let emoji = "";
 
-	game.engine.sendAction({
-		$case: "setEmojiStatus",
-		setEmojiStatus: {
-			emojiStatus: "🎶",
-		},
-	});
-	game.engine.sendAction({
-		$case: "setTextStatus",
-		setTextStatus: {
-			textStatus: res.data.item.name,
-		},
-	});
+  if (res.data.is_playing === true) {
+    if (res.data.currently_playing_type === "track") {
+      playing =
+        res.data.item.name + " ∙ " + res.data.item.artists[0].name + " (Spotify)";
+      emoji = "🎶";
+    } else if (res.data.currently_playing_type === "episode") {
+      playing = "listening to some podcast (Spotify)";
+      emoji = "🎧";
+    }
+    else console.log("unexpected value in 'currently_playing_type'")
+  }
+  else { // listening to nothing
+    playing = "";
+    emoji = "";
+  }; 
+
+  if (playing !== "") {
+    console.log(playing);
+  }
+  else console.log("stopped listening");
+
+  game.engine.sendAction({
+    $case: "setEmojiStatus",
+    setEmojiStatus: {
+      emojiStatus: emoji,
+    },
+  });
+  game.engine.sendAction({
+    $case: "setTextStatus",
+    setTextStatus: {
+      textStatus: playing,
+    },
+  });
 }, 5000);

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { API_KEY, SPACE_ID, CLIENT_ID, CLIENT_SECRET, ACCESS_TOKEN, REFRESH_TOKEN } from "./api-key";
 import { Game } from "@gathertown/gather-game-client";
 global.WebSocket = require("isomorphic-ws");

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@gathertown/gather-game-client": "32.0.0",
-        "axios": "^0.24.0",
         "isomorphic-ws": "^4.0.1",
         "spotify-oauth-refresher": "^1.0.8",
         "ws": "^8.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,409 @@
 {
   "name": "mod-spotify-as-status",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "mod-spotify-as-status",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@gathertown/gather-game-client": "32.0.0",
+        "axios": "^0.24.0",
+        "isomorphic-ws": "^4.0.1",
+        "spotify-oauth-refresher": "^1.0.8",
+        "ws": "^8.2.1"
+      },
+      "devDependencies": {
+        "@types/node": "^16.7.10",
+        "typescript": "4.3.4"
+      }
+    },
+    "node_modules/@gathertown/gather-game-client": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@gathertown/gather-game-client/-/gather-game-client-32.0.0.tgz",
+      "integrity": "sha512-OmcXL2BTeGqxxoMdVMRk2bQg1jvXt6CfxnytsbEaFFqWM87Q+uxLnQ2LdzxtaLUmfZkcTW6sMXU+IyLhc9Pzsg==",
+      "dependencies": {
+        "@gathertown/gather-game-common": "^23.0.0",
+        "@types/node": "^14.14.9",
+        "axios": "^0.21.1",
+        "buffer": "^6.0.3",
+        "lodash": "^4.17.20",
+        "recursive-diff": "^1.0.8",
+        "uuid": "^8.3.1"
+      }
+    },
+    "node_modules/@gathertown/gather-game-client/node_modules/@types/node": {
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+    },
+    "node_modules/@gathertown/gather-game-client/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@gathertown/gather-game-common": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@gathertown/gather-game-common/-/gather-game-common-23.0.0.tgz",
+      "integrity": "sha512-ne46Xcq/OtaJfM2/c+8SEKMS5UuEkaQAywH6aputcAbq/Qnk1LScRz/swGjQZzeJbkr/VznY//zziI0BgCvX6Q==",
+      "dependencies": {
+        "@types/node": "^14.14.9",
+        "buffer": "^6.0.3",
+        "ts-proto": "^1.82.2"
+      }
+    },
+    "node_modules/@gathertown/gather-game-common/node_modules/@types/node": {
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw=="
+    },
+    "node_modules/@types/object-hash": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-1.3.4.tgz",
+      "integrity": "sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA=="
+    },
+    "node_modules/@types/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ=="
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/recursive-diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/recursive-diff/-/recursive-diff-1.0.8.tgz",
+      "integrity": "sha512-WfUcVao/HRsZZjI96PjcefTZ87rsxrgryIlWJB2UrHs4v3kFFzvMOm801a1WoqG+IAsLKJPsGlvubR74EDqGWQ=="
+    },
+    "node_modules/spotify-oauth-refresher": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/spotify-oauth-refresher/-/spotify-oauth-refresher-1.0.8.tgz",
+      "integrity": "sha512-OsoCVflepaOGh2PyI67jOpO4kHXH29MuNbkYXkhLhpJrUN9SQVCIlbn35b87DTfXl9xaKSPwQJfsPnRgpVd7eA==",
+      "dependencies": {
+        "axios": "^0.24.0",
+        "universal-cookie": "^4.0.4"
+      }
+    },
+    "node_modules/ts-poet": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-4.6.1.tgz",
+      "integrity": "sha512-DXJ+mBJIDp+jiaUgB4N5I/sczHHDU2FWacdbDNVAVS4Mh4hb7ckpvUWVW7m7/nAOcjR0r4Wt+7AoO7FeJKExfA==",
+      "dependencies": {
+        "@types/prettier": "^1.19.0",
+        "lodash": "^4.17.15",
+        "prettier": "^2.0.2"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "1.92.1",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.92.1.tgz",
+      "integrity": "sha512-ofs0Drr2NNhZyl4zC7pCbSs2U4cBG5A8xXbgPYWTqsYew8HtwofoekhhAUXcgsMzo1G56MGagTZYZayqOKvN9A==",
+      "dependencies": {
+        "@types/object-hash": "^1.3.0",
+        "dataloader": "^1.4.0",
+        "object-hash": "^1.3.1",
+        "protobufjs": "^6.8.8",
+        "ts-poet": "^4.5.0",
+        "ts-proto-descriptors": "^1.2.1"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.3.1.tgz",
+      "integrity": "sha512-Cybb3fqceMwA6JzHdC32dIo8eVGVmXrM6TWhdk1XQVVHT/6OQqk0ioyX1dIdu3rCIBhRmWUhUE4HsyK+olmgMw==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
+      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  },
   "dependencies": {
     "@gathertown/gather-game-client": {
       "version": "32.0.0",
@@ -104,6 +505,11 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -146,6 +552,11 @@
         "ieee754": "^1.2.1"
       }
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
     "dataloader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
@@ -164,7 +575,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "lodash": {
       "version": "4.17.21",
@@ -211,6 +623,15 @@
       "resolved": "https://registry.npmjs.org/recursive-diff/-/recursive-diff-1.0.8.tgz",
       "integrity": "sha512-WfUcVao/HRsZZjI96PjcefTZ87rsxrgryIlWJB2UrHs4v3kFFzvMOm801a1WoqG+IAsLKJPsGlvubR74EDqGWQ=="
     },
+    "spotify-oauth-refresher": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/spotify-oauth-refresher/-/spotify-oauth-refresher-1.0.8.tgz",
+      "integrity": "sha512-OsoCVflepaOGh2PyI67jOpO4kHXH29MuNbkYXkhLhpJrUN9SQVCIlbn35b87DTfXl9xaKSPwQJfsPnRgpVd7eA==",
+      "requires": {
+        "axios": "^0.24.0",
+        "universal-cookie": "^4.0.4"
+      }
+    },
     "ts-poet": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-4.6.1.tgz",
@@ -249,6 +670,15 @@
       "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -257,7 +687,8 @@
     "ws": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw=="
+      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@gathertown/gather-game-client": "32.0.0",
     "axios": "^0.24.0",
     "isomorphic-ws": "^4.0.1",
+    "spotify-oauth-refresher": "^1.0.8",
     "ws": "^8.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "homepage": "https://github.com/gathertown/mod-spotify-as-status#readme",
   "dependencies": {
     "@gathertown/gather-game-client": "32.0.0",
-    "axios": "^0.24.0",
     "isomorphic-ws": "^4.0.1",
     "spotify-oauth-refresher": "^1.0.8",
     "ws": "^8.2.1"


### PR DESCRIPTION
The _access_token_ renews automatically (fixes issue #1). Thanks to the embedded [Spotify OAuth Refresher](https://github.com/matievisthekat/spotify-oauth-refresher) by  @matievisthekat, the mod can now run continuously without having to refresh the token manually.

Additional data required:
- [client_id & client_secret](https://developer.spotify.com/dashboard/applications) (you need to create a Spotify API app to get these).
- [refresh_token](https://developer.spotify.com/console/get-users-currently-playing-track/) (as given in the  [Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization/code-flow/), same as _acces_token_)

Also, a distinction has made between listening to music and podcast episodes (illustrated by an additional emoji). This is needed to prevent errors because the API response when listening to "shows" results in incomplete title data.

When listening to an episode, "*listening to some podcast*" appears in the Gather status now.